### PR TITLE
feat(dev): add Docker-based development environment with Makefile integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## [Unreleased]
+
+### Added
+- Docker-based development environment:
+  - Dockerfile with Node.js 20, Python 3, GCC, Rust, and `tree-sitter-cli`
+  - `compose.yaml` for container orchestration
+- Makefile enhancements:
+  - `help`, `build`, `test`, `build-docker`, and `version` targets
+  - Strict Bash mode (`-eu -o pipefail`) and clean Make defaults
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM rockylinux:9
+
+# Install system dependencies
+RUN dnf install -y dnf-plugins-core && \
+    dnf install -y --allowerasing \
+    gcc gcc-c++ make python3 python3-devel \
+    curl git tar bzip2 xz findutils \
+    glibc-devel libstdc++-devel && \
+    dnf module reset nodejs -y && \
+    dnf module enable nodejs:20 -y && \
+    dnf install -y nodejs npm && \
+    npm install -g node-gyp node-gyp-build && \
+    rm -rf /var/cache/dnf
+
+# Install cargo and tree-sitter-cli
+RUN curl -o sh.rustup.rs https://sh.rustup.rs -sSf && \
+    echo "b25b33de9e5678e976905db7f21b42a58fb124dd098b35a962f963734b790a9b  sh.rustup.rs" | sha256sum -c - && \
+    sh sh.rustup.rs -y && \
+    $HOME/.cargo/bin/cargo install --locked tree-sitter-cli
+
+# Set Python for node-gyp
+ENV PYTHON=/usr/bin/python3
+
+# Set working directory
+WORKDIR /app
+COPY . /app
+
+# Install project dependencies
+RUN npm install
+
+CMD ["node"]

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,40 @@
+# Make Config
+## ==============================
+SHELL = bash
+# Enable bash strict mode.
+.SHELLFLAGS := -eu -o pipefail -c
+## Change some Defaults of Make.
+# Ensures each Make recipe is ran as one single shell session,
+# rather than one new shell per line.
+.ONESHELL:
+MAKEFLAGS += --warn-undefined-variables
+MAKEFLAGS += --no-builtin-rules
+
+# Help
+## ==============================
+help: ## Show this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z0-9_-]+:.*?## / {sub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-25s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
+
 .PHONY: build
+build: parser/tcl.so ## Build the tree-sitter-tcl parser
 
-build: parser/tcl.so
-
-parser/tcl.so: src/parser.c src/scanner.c
+parser/tcl.so: src/parser.c src/scanner.c ## Compile parser C files into shared object
 	$(RM) $@
 	mkdir -p parser
 	tree-sitter build -o $@
 
-src/parser.c: grammar.js
+src/parser.c: grammar.js ## Generate parser source from grammar.js
 	tree-sitter generate
 
 .PHONY: test
-test: parser/tcl.so
+test: parser/tcl.so ## Run tree-sitter tests
 	tree-sitter test
+
+.PHONY: build-docker
+build-docker: ## Build the tree-sitter-tcl Docker image
+	docker compose build tree-sitter-tcl
+
+.PHONY: build-docker
+version: build-docker ## Tag new tree-sitter-tcl semver
+	read -p "version: " version
+	docker compose run --rm tree-sitter-tcl /root/.cargo/bin/tree-sitter version $$version

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,11 @@
+services:
+  tree-sitter-tcl:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: tree-sitter-tcl:dev
+    volumes:
+      - .:/app
+      - /app/node_modules
+    working_dir: /app
+    command: ["bash"]


### PR DESCRIPTION
This PR introduces a containerized development environment for `tree-sitter-tcl` to improve consistency and portability across systems.

### 🔧 What's Included

- **Dockerfile** based on `rockylinux:9` with:
  - Node.js 20 + npm
  - Python 3 + build tools
  - GCC + Rust via `rustup`
  - Global install of `tree-sitter-cli`
- **docker-compose.yaml** for running the dev container with project files mounted
- **Makefile enhancements**:
  - Strict Bash shell settings (`-eu -o pipefail`)
  - Targets for:
    - `build`: build the parser
    - `test`: run the test suite
    - `build-docker`: build the Docker image
    - `version`: tag the grammar version inside the container
    - `help`: auto-generates help for available make targets

This enables seamless setup and development, regardless of the host OS.
