### PR TITLE
chore(highlights): reorder @spell before @comment to work around zed#27535

### DIFF
--- a/queries/tcl/highlights.scm
+++ b/queries/tcl/highlights.scm
@@ -1,5 +1,4 @@
-
-(comment) @comment @spell
+(comment) @spell @comment
 
 (command name: (simple_word) @function)
 


### PR DESCRIPTION
Reorders highlight captures in `queries/tcl/highlights.scm` so `@spell` appears before `@comment`. This works around a bug in Zed where only the first capture is respected for spellchecking.

This change did not appear to break spell checking (in comments) in Neovim.

See: zed-industries/zed#27535