### PR TITLE
chore(highlights): add fallback captures for broader theme compatibility

### DIFF
--- a/queries/tcl/highlights.scm
+++ b/queries/tcl/highlights.scm
@@ -3,7 +3,7 @@
 
 (command name: (simple_word) @function)
 
-"proc" @keyword.function
+"proc" @keyword.function @keyword
 
 (procedure
   name: (_) @variable
@@ -12,10 +12,10 @@
 (set (simple_word) @variable)
 
 (argument
-  name: (_) @variable.parameter
+  name: (_) @variable.parameter @variable
 )
 
-((simple_word) @variable.builtin
+((simple_word) @variable.builtin @variable
                (#any-of? @variable.builtin
                 "argc"
                 "argv"
@@ -38,10 +38,10 @@
                 "tcl_version"))
 
 
-"expr" @function.builtin
+"expr" @function.builtin @function
 
 (command
-  name: (simple_word) @function.builtin
+  name: (simple_word) @function.builtin @function
   (#any-of? @function.builtin
    "cd"
    "exec"
@@ -103,13 +103,13 @@
  "while"
  "foreach"
  ; "for"
- ] @repeat
+ ] @repeat @keyword
 
 [
  "if"
  "else"
  "elseif"
- ] @conditional
+ ] @conditional @keyword
 
 [
  "**"
@@ -134,7 +134,7 @@
  "{" "}"
  "[" "]"
  ";"
- ] @punctuation.delimiter
+ ] @punctuation.bracket @punctuation.delimiter
 
 ((simple_word) @number
                (#lua-match? @number "^[0-9]+$"))


### PR DESCRIPTION
Adds fallback highlight captures (e.g. @variable, @keyword, @function) alongside more specific ones like @variable.parameter and @keyword.function. This improves compatibility with generalized themes that may not support the full range of Tree-sitter capture groups.