### PR TITLE
fix(highlighting): replace #lua-match? with #match? for numeric literals

### DIFF
--- a/queries/tcl/highlights.scm
+++ b/queries/tcl/highlights.scm
@@ -137,7 +137,7 @@
  ] @punctuation.delimiter
 
 ((simple_word) @number
-               (#lua-match? @number "^[0-9]+$"))
+               (#match? @number "^[0-9]+$"))
 
 ((simple_word) @boolean
                (#any-of? @boolean "true" "false"))


### PR DESCRIPTION
Use Tree-sitter's native `#match?` predicate instead of `#lua-match?` to ensure compatibility with editors like Zed which may not support Lua-based queries. This prevents incorrect highlighting of non-numeric simple_word nodes like "switch".