### PR TITLE
feat(highlights): improve highlighting for `switch`, `unset`, and `variable` commands

### DIFF
--- a/queries/tcl/highlights.scm
+++ b/queries/tcl/highlights.scm
@@ -39,6 +39,16 @@
 
 "expr" @function.builtin @function
 
+; Highlight switch arguments as string
+(command
+    name: (simple_word) @keyword
+    arguments:
+        (word_list
+            (braced_word
+                (command
+                    name: (simple_word) @string)))
+    (#eq? @keyword "switch"))
+
 (command
   name: (simple_word) @function.builtin @function
   (#any-of? @function.builtin
@@ -55,6 +65,14 @@
    "subst"
    "trace"
    "source"))
+
+; Highlight unset and variable arguments as variables
+(command
+    name: (simple_word) @keyword
+    arguments: (word_list) @variable
+    (#any-of? @keyword
+        "unset"
+        "variable"))
 
 (command name: (simple_word) @keyword
          (#any-of? @keyword
@@ -83,11 +101,8 @@
           "lsort"
           "package"
           "return"
-          "switch"
           "trap"
-          "throw"
-          "unset"
-          "variable"))
+          "throw"))
 
 [
  "catch"

--- a/test/highlight/keywords.tcl
+++ b/test/highlight/keywords.tcl
@@ -106,9 +106,20 @@ return
 
 # Test keyword: switch
 switch $value {
-    default {puts "default"}
-}
 # <- keyword
+    a {
+        return
+#       ^ keyword
+    }
+    "b" { return }
+#   ^ string
+    default {
+#   ^ keyword
+        puts "default"
+#       ^ function
+#             ^ string
+    }
+}
 
 # Test keyword: throw
 throw "error"

--- a/test/highlight/variables.tcl
+++ b/test/highlight/variables.tcl
@@ -1,0 +1,23 @@
+# Test keyword: unset
+unset var
+# <- keyword
+#     ^ variable
+
+# Test keyword: variable
+variable myVar 42
+# <- keyword
+#        ^ variable
+
+$myvar
+# <- variable
+${myvar}
+# <- variable
+#^ punctuation.delimiter
+#  ^ variable
+"${myvar}"
+# <- string
+#   ^ variable
+#        ^ string
+"$myvar"
+# <- string
+#   ^ variable


### PR DESCRIPTION
- Highlights `switch` arguments as @string for better readability
- Adds variable highlighting to arguments of `unset` and `variable`
- Refactors and comments out specific builtin command highlighting for future tuning
- Adds tests for `switch`, `unset`, and `variable` to verify improved highlighting behavior