### PR TITLE
ci: upgrade to parser-test-action@v2 and setup-action/cli@v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,14 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
     steps:
-      - uses: tree-sitter/parser-setup-action@v1.1
+      - uses: actions/checkout@v4
+      - uses: tree-sitter/setup-action/cli@v1
+      - uses: tree-sitter/parser-test-action@v2
         with:
-          node-version: ${{vars.NODE_VERSION}}
-      - uses: tree-sitter/parser-test-action@v1.2
-        with:
-          test-library: false
+          generate: true
+          test-parser: true
+          test-node: true
+
   fuzz:
     name: Fuzz parser
     runs-on: ubuntu-latest


### PR DESCRIPTION
[tree-sitter/parser-setup-action@v1.2](https://github.com/tree-sitter/parser-setup-action) is deprecated and has been replaced with [tree-sitter/parser-test-action@v2](https://github.com/tree-sitter/parser-test-action)

- Replace deprecated tree-sitter/parser-setup-action@v1.1 with tree-sitter/setup-action/cli@v1
- Upgrade to tree-sitter/parser-test-action@v2
- Enable `generate`, `test-parser`, and `test-node`