### PR TITLE
fix(ci): remove node tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - .github/workflows/**
       - grammar.js
       - src/**
       - test/**
@@ -11,6 +12,7 @@ on:
       - binding.gyp
   pull_request:
     paths:
+      - .github/workflows/**
       - grammar.js
       - src/**
       - test/**
@@ -36,7 +38,7 @@ jobs:
         with:
           generate: true
           test-parser: true
-          test-node: true
+          # test-node: true
 
   fuzz:
     name: Fuzz parser


### PR DESCRIPTION
we are not exporting any node modules yet, so removing node tests for now and will add them back later when we start to deploy to npm